### PR TITLE
Add docs, linting and new Go version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+on:
+  pull_request:
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.20
+      - uses: actions/checkout@v3
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.53.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,32 @@
 upcloud-go-instance-metadata
+
+# Created by https://www.gitignore.io/api/macos
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# End of https://www.gitignore.io/api/macos

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,55 @@
+# Golang CI pipeline configuration
+linters:
+  disable-all: true
+
+  # Run golangci-lint linters to see the list of all linters
+  # Please keep them sorted alphabetically
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - dogsled
+    - errcheck
+    - goconst
+    - gofumpt
+    - goimports
+    - gomoddirectives
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - nolintlint
+    - nosprintfhostport
+    - predeclared
+    - revive
+    - rowserrcheck
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unused
+    - wastedassign
+    - whitespace
+
+output:
+  uniq-by-line: false
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - funlen
+        - bodyclose
+
+linters-settings:
+  goconst:
+    min-len: 5
+  predeclared:
+    ignore: "new"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test 
+test:
+	go test ./...
+
+.PHONY: lint
+lint:
+	golangci-lint run

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # UpCloud instance metadata Go library
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/UpCloudLtd/upcloud-go-instance-metadata.svg)](https://pkg.go.dev/github.com/UpCloudLtd/upcloud-go-instance-metadata)
+
 Go library for reading UpCloud server instance metadata from `http://169.254.169.254/metadata/v1.json`.
 
 ## Installation
@@ -12,19 +14,4 @@ go get github.com/UpCloudLtd/upcloud-go-instance-metadata
 
 ## Usage
 
-To fetch and unmarshal instance metadata, call `metadata.Read()`, for example:
-
-```go
-package main
-
-import (
-	"log"
-
-	"github.com/UpCloudLtd/upcloud-go-instance-metadata/metadata"
-)
-
-func main() {
-	m, _ := metadata.Read()
-	log.Printf("I'm at '%s' and my instance ID is '%s'", m.Region, m.InstanceID)
-}
-```
+To fetch an unmarshal instance metadata, see [example](metadata/example_read_test.go).

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/UpCloudLtd/upcloud-go-instance-metadata
 
-go 1.18
+go 1.20

--- a/metadata/example_read_test.go
+++ b/metadata/example_read_test.go
@@ -1,4 +1,4 @@
-package main
+package metadata_test
 
 import (
 	"log"
@@ -6,7 +6,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-instance-metadata/metadata"
 )
 
-func main() {
+func Example_read() {
 	m, _ := metadata.Read()
 	log.Printf("I'm at '%s' and my instance ID is '%s'", m.Region, m.InstanceID)
 }

--- a/metadata/read.go
+++ b/metadata/read.go
@@ -2,7 +2,7 @@ package metadata
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -16,7 +16,7 @@ func Read() (*InstanceMetadata, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/metadata/types.go
+++ b/metadata/types.go
@@ -24,7 +24,7 @@ type NetworkInterface struct {
 	Index       int         `json:"index"`
 	IPAddresses []IPAddress `json:"ip_addresses"`
 	MAC         string      `json:"mac"`
-	NetworkId   string      `json:"network_id"`
+	NetworkID   string      `json:"network_id"`
 	Type        string      `json:"type"`
 }
 


### PR DESCRIPTION
- Add linting configs and pipeline
- Use Go 1.20 and update deprecated ioutil reference
- Fix `NetworkID` field name
- Move example to a file format which is understood by `godoc`
- Improve `.gitignore`
- Add Makefile